### PR TITLE
enhance/51: Slightly tighten down battle time

### DIFF
--- a/client/src/components/match/battle/BattleColumns.tsx
+++ b/client/src/components/match/battle/BattleColumns.tsx
@@ -24,120 +24,120 @@ import styles from "./BattleColumns.module.scss";
  */
 
 type BattleColumnsProps = {
-    yourValue: number;
-    opponentValue: number;
-    isStatBubbleAnimFinished: boolean;
-    onFinished: () => void;
+  yourValue: number;
+  opponentValue: number;
+  isStatBubbleAnimFinished: boolean;
+  onFinished: () => void;
 };
 
 export default function BattleColumns({
-    yourValue,
-    opponentValue,
-    isStatBubbleAnimFinished,
-    onFinished,
+  yourValue,
+  opponentValue,
+  isStatBubbleAnimFinished,
+  onFinished,
 }: BattleColumnsProps) {
-    const [currentUpperHeight, setCurrentUpperHeight] = useState(0);
-    const [currentLowerHeight, setCurrentLowerHeight] = useState(0);
+  const [currentUpperHeight, setCurrentUpperHeight] = useState(0);
+  const [currentLowerHeight, setCurrentLowerHeight] = useState(0);
 
-    const [upperValue, setUpperValue] = useState(0);
-    const [lowerValue, setLowerValue] = useState(0);
+  const [upperValue, setUpperValue] = useState(0);
+  const [lowerValue, setLowerValue] = useState(0);
 
-    const total = yourValue + opponentValue;
-    const lowerHeightPercent = (yourValue / total) * 100;
-    const upperHeightPercent = (opponentValue / total) * 100;
+  const total = yourValue + opponentValue;
+  const lowerHeightPercent = (yourValue / total) * 100;
+  const upperHeightPercent = (opponentValue / total) * 100;
 
-    let upperGrowthInterval: ReturnType<typeof setInterval>;
-    let lowerGrowthInterval: ReturnType<typeof setInterval>;
+  let upperGrowthInterval: ReturnType<typeof setInterval>;
+  let lowerGrowthInterval: ReturnType<typeof setInterval>;
 
-    const [isGrowing, setIsGrowing] = useState({ upper: false, lower: false });
-    const [growingFinished, setGrowingFinished] = useState(false);
+  const [isGrowing, setIsGrowing] = useState({ upper: false, lower: false });
+  const [growingFinished, setGrowingFinished] = useState(false);
 
-    const INTERVAL_TIMER = 50;
-    const DELAY_BETWEEN_GROWTH_AND_OUTCOME = 500;
-    const DELAY_BETWEEN_GROWTH_AND_FINISH = 2500;
+  const INTERVAL_TIMER = 50;
+  const DELAY_BETWEEN_GROWTH_AND_OUTCOME = 150;
+  const DELAY_BETWEEN_GROWTH_AND_FINISH = 1900;
 
-    const isTie = opponentValue === yourValue;
-    const upperWon = opponentValue > yourValue;
+  const isTie = opponentValue === yourValue;
+  const upperWon = opponentValue > yourValue;
 
-    // upper column growth
-    useEffect(() => {
-        if (!isStatBubbleAnimFinished) return;
-        upperGrowthInterval = setInterval(() => {
-            setCurrentUpperHeight((prev) => {
-                setUpperValue(Math.round((prev / 100) * total));
-                if (prev < upperHeightPercent) {
-                    return prev + 1;
-                } else {
-                    setUpperValue(opponentValue);
-                    clearInterval(upperGrowthInterval);
-                    setIsGrowing((prev) => ({ ...prev, upper: true }));
-                    return prev;
-                }
-            });
-        }, INTERVAL_TIMER);
-        return () => clearInterval(upperGrowthInterval);
-    }, [isStatBubbleAnimFinished]);
-
-    // lower column growth
-    useEffect(() => {
-        if (!isStatBubbleAnimFinished) return;
-        lowerGrowthInterval = setInterval(() => {
-            setCurrentLowerHeight((prev) => {
-                setLowerValue(Math.round((prev / 100) * total));
-                if (prev < lowerHeightPercent) {
-                    return prev + 1;
-                } else {
-                    setLowerValue(yourValue);
-                    clearInterval(lowerGrowthInterval);
-                    setIsGrowing((prev) => ({ ...prev, lower: true }));
-                    return prev;
-                }
-            });
-        }, INTERVAL_TIMER);
-        return () => clearInterval(lowerGrowthInterval);
-    }, [isStatBubbleAnimFinished]);
-
-    // both columns finished growing
-    useEffect(() => {
-        let [timerA, timerB]: ReturnType<typeof setTimeout>[] = [];
-        if (isGrowing.upper && isGrowing.lower) {
-            timerA = setTimeout(() => {
-                setGrowingFinished(true);
-            }, DELAY_BETWEEN_GROWTH_AND_OUTCOME);
-            timerB = setTimeout(() => {
-                onFinished();
-            }, DELAY_BETWEEN_GROWTH_AND_FINISH);
+  // upper column growth
+  useEffect(() => {
+    if (!isStatBubbleAnimFinished) return;
+    upperGrowthInterval = setInterval(() => {
+      setCurrentUpperHeight((prev) => {
+        setUpperValue(Math.round((prev / 100) * total));
+        if (prev < upperHeightPercent) {
+          return prev + 1;
+        } else {
+          setUpperValue(opponentValue);
+          clearInterval(upperGrowthInterval);
+          setIsGrowing((prev) => ({ ...prev, upper: true }));
+          return prev;
         }
-        return () => {
-            clearTimeout(timerA);
-            clearTimeout(timerB);
-        };
-    }, [isGrowing]);
+      });
+    }, INTERVAL_TIMER);
+    return () => clearInterval(upperGrowthInterval);
+  }, [isStatBubbleAnimFinished]);
 
-    return (
-        <div className={styles.columnsContainer}>
-            <div
-                className={`
+  // lower column growth
+  useEffect(() => {
+    if (!isStatBubbleAnimFinished) return;
+    lowerGrowthInterval = setInterval(() => {
+      setCurrentLowerHeight((prev) => {
+        setLowerValue(Math.round((prev / 100) * total));
+        if (prev < lowerHeightPercent) {
+          return prev + 1;
+        } else {
+          setLowerValue(yourValue);
+          clearInterval(lowerGrowthInterval);
+          setIsGrowing((prev) => ({ ...prev, lower: true }));
+          return prev;
+        }
+      });
+    }, INTERVAL_TIMER);
+    return () => clearInterval(lowerGrowthInterval);
+  }, [isStatBubbleAnimFinished]);
+
+  // both columns finished growing
+  useEffect(() => {
+    let [timerA, timerB]: ReturnType<typeof setTimeout>[] = [];
+    if (isGrowing.upper && isGrowing.lower) {
+      timerA = setTimeout(() => {
+        setGrowingFinished(true);
+      }, DELAY_BETWEEN_GROWTH_AND_OUTCOME);
+      timerB = setTimeout(() => {
+        onFinished();
+      }, DELAY_BETWEEN_GROWTH_AND_FINISH);
+    }
+    return () => {
+      clearTimeout(timerA);
+      clearTimeout(timerB);
+    };
+  }, [isGrowing]);
+
+  return (
+    <div className={styles.columnsContainer}>
+      <div
+        className={`
                     ${styles.column} 
                     ${styles.upperColumn} 
                     ${growingFinished && !isTie && !upperWon ? styles.lowlight : ""}
                     ${growingFinished && !isTie && upperWon ? styles.upperHighlight : ""}
                 `}
-                style={{ height: `${currentUpperHeight}%` }}
-            >
-                <span className={styles.valueText}>{upperValue}</span>
-            </div>
-            <div
-                className={`
+        style={{ height: `${currentUpperHeight}%` }}
+      >
+        <span className={styles.valueText}>{upperValue}</span>
+      </div>
+      <div
+        className={`
                     ${styles.column} 
                     ${styles.lowerColumn} 
                     ${growingFinished && !isTie && upperWon ? styles.lowlight : ""}
                     ${growingFinished && !isTie && !upperWon ? styles.lowerHighlight : ""}
                 `}
-                style={{ height: `${currentLowerHeight}%` }}
-            >
-                <span className={styles.valueText}>{lowerValue}</span>
-            </div>
-        </div>
-    );
+        style={{ height: `${currentLowerHeight}%` }}
+      >
+        <span className={styles.valueText}>{lowerValue}</span>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
Turns out there wasn't all that much time to cut.

There is just no good middle ground between:
- Slow enough for first time players to follow along
- Fast enough for returning players to not get bored

Some time during columns finished and attack start was shaved off, otherwise the
solution likely has to be to implement a fast mode that can be toggled via room options.
It's unlikely to ever be worth the effort though, so likely this just is what it is for this matter.